### PR TITLE
Migrate from ASP.NET Core 3.1 to 5.0

### DIFF
--- a/IntegrationContainers.API/Dockerfile
+++ b/IntegrationContainers.API/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS build
 WORKDIR /src
 COPY ["IntegrationContainers.API/IntegrationContainers.API.csproj", "IntegrationContainers.API/"]
 RUN dotnet restore "IntegrationContainers.API/IntegrationContainers.API.csproj"

--- a/IntegrationContainers.API/IntegrationContainers.API.csproj
+++ b/IntegrationContainers.API/IntegrationContainers.API.csproj
@@ -1,13 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.10">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.11.1" />
   </ItemGroup>
 

--- a/IntegrationContainers.Data/IntegrationContainers.Data.csproj
+++ b/IntegrationContainers.Data/IntegrationContainers.Data.csproj
@@ -1,13 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # testcontainers-aspnet-integration-tests
 [![Build status](https://ci.appveyor.com/api/projects/status/2xd5wkyy9laelcow?svg=true)](https://ci.appveyor.com/project/nazimkov/testcontainers-aspnet-integration-tests)
 
-.NET Core 3.1 API + EF Core + MSSQL example application which utilize integration testing using Docker containers for throwaway DB instance. 
+ASP.NET Core 5.0 API + EF Core + MSSQL example application which utilize integration testing using Docker containers for throwaway DB instance. 
 
 The integration testing implemented with help of:
 
@@ -12,7 +12,7 @@ The integration testing implemented with help of:
 
 ## Project structure
 
-1. `IntegrationContainers.API` - .NET Core 3.1 API 
+1. `IntegrationContainers.API` - .NET Core 5.A PI 
 2. `IntegrationContainers.Data` - sort of Data Access Layer with EF Core Db Context , entities, migrations
 3. `IntegrationContainers.API.Tests` - integration tests with fixtures setup
 
@@ -25,3 +25,4 @@ Before running unit tests:
 2. Pull SQL Server image:
 
    ```docker pull mcr.microsoft.com/mssql/server:2017-latest-ubuntu```
+

--- a/tests/IntegrationContainers.API.Tests/IntegrationContainers.API.Tests.csproj
+++ b/tests/IntegrationContainers.API.Tests/IntegrationContainers.API.Tests.csproj
@@ -1,13 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.10">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Respawn" Version="4.0.0" />
     <PackageReference Include="TestContainers.Container.Database.MsSql" Version="1.5.0" />


### PR DESCRIPTION
- Update target framework to `net5.0`
- Update NuGet packages
- Update Docker base image to `mcr.microsoft.com/dotnet/aspnet:5.0`